### PR TITLE
Docs, license in script source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,1 @@
 DFHACK_SCRIPTS(gui/quickcmd.lua SUBDIRECTORY gui)
-DFHACK_SCRIPTS(LICENSE SUBDIRECTORY gui/quickcmdlicense)

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,3 @@ MaienM's scripts
 ================
 
 Some scripts and utilities I made for DFHack.
-
-gui/quickcmd
-============
-A list of commands which you can edit while in-game, and which you can execute
-quickly and easily. For stuff you use often enough to not want to type it, but
-not often enough to be bothered to find a free keybinding.

--- a/gui/quickcmd.lua
+++ b/gui/quickcmd.lua
@@ -1,4 +1,43 @@
 --- Simple menu to quickly execute common commands.
+--[[=begin
+
+gui/quickcmd
+============
+A list of commands which you can edit while in-game, and which you can execute
+quickly and easily. For stuff you use often enough to not want to type it, but
+not often enough to be bothered to find a free keybinding.
+
+=end]]
+
+--[[
+Copyright (c) 2014, Michon van Dooren
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+]]
 
 local gui = require 'gui'
 local widgets = require 'gui.widgets'


### PR DESCRIPTION
For DFHack pull 713.

Keep the script and license in the same file, to prevent both clutter and confusion - adding a new license file in a subdirectory is asking for trouble, and it didn't even specify what the license referred to!
